### PR TITLE
Ajout composant NextPrevSelect

### DIFF
--- a/components/next_prev_select/index.css
+++ b/components/next_prev_select/index.css
@@ -1,0 +1,18 @@
+.nextPrevSelect > .ant-select-selector {
+    border-radius: 0px !important;
+}
+
+.nextPrevSelect-left-button {
+    border-radius: 0px !important;
+    border-top-left-radius: 4px !important;
+    border-bottom-left-radius: 4px !important;
+    border-right:0px !important;
+
+}
+
+.nextPrevSelect-right-button {
+    border-radius: 0px !important;
+    border-top-right-radius: 4px !important;
+    border-bottom-right-radius: 4px !important;
+    border-left:0px !important;
+}

--- a/components/next_prev_select/index.tsx
+++ b/components/next_prev_select/index.tsx
@@ -1,16 +1,15 @@
 import { CaretLeftOutlined, CaretRightOutlined } from "@ant-design/icons"
-import { Button, Flex, Select, } from "antd"
+import { Button, Flex, Select, SelectProps} from "antd"
 import { CSSProperties, useEffect, useState } from "react"
-
 import './index.css'
 
 
-export interface NextPrevSelectProps {
-    options?:any[]
+export interface NextPrevSelectProps  {
+    options:SelectProps['options']
     style?:CSSProperties
-    defaultValue?:string
-    value?:string
-    onChange?:Function
+    defaultValue?:string | number
+    value:string | number
+    onChange?: (value: string | number) => void;
     reverse?:boolean // False : next = goDown
   }
 
@@ -22,19 +21,19 @@ export const NextPrevSelect: React.FC<NextPrevSelectProps> = ({
   onChange,
   reverse = false,
 }) => {
-  const [current_value, setCurrent_value] = useState(value);
+  const [current_value, setCurrent_value] = useState<string | number>(value);
 
   const current_index = options?.findIndex((o) => o.value == current_value);
 
   const next = () =>
     reverse
-      ? options[current_index - 1].value
-      : options[current_index + 1].value;
+      ? options[current_index - 1].value!
+      : options[current_index + 1].value!;
 
   const previous = () =>
     reverse
-      ? options[current_index + 1].value
-      : options[current_index - 1].value;
+      ? options[current_index + 1].value!
+      : options[current_index - 1].value!;
 
   const isFirst = () =>
     reverse ? current_index == options.length - 1 : current_index == 0;
@@ -44,7 +43,7 @@ export const NextPrevSelect: React.FC<NextPrevSelectProps> = ({
 
 
   useEffect(() => {
-    onChange && onChange(current_value);
+    onChange && onChange(current_value.toString());
   }, [current_value])
 
 

--- a/components/next_prev_select/index.tsx
+++ b/components/next_prev_select/index.tsx
@@ -1,7 +1,8 @@
-import { LeftCircleOutlined, LeftOutlined, RightCircleOutlined, RightOutlined, VerticalLeftOutlined, VerticalRightOutlined } from "@ant-design/icons"
+import { CaretLeftOutlined, CaretRightOutlined } from "@ant-design/icons"
 import { Button, Flex, Select, } from "antd"
 import { CSSProperties, useEffect, useState } from "react"
 
+import './index.css'
 
 
 export interface NextPrevSelectProps {
@@ -49,18 +50,19 @@ export const NextPrevSelect: React.FC<NextPrevSelectProps> = ({
 
   return (
     <Flex style={style}>
-      <Button onClick={() => setCurrent_value(previous())} disabled={isFirst()}>
-      <LeftCircleOutlined />
+      <Button className="nextPrevSelect-left-button" onClick={() => setCurrent_value(previous())} disabled={isFirst()}>
+      <CaretLeftOutlined />
       </Button>
       <Select
+        className="nextPrevSelect"
         options={options}
         style={style}
         value={current_value}
         defaultValue={defaultValue}
         onChange={setCurrent_value}
       />
-      <Button onClick={() => setCurrent_value(next())} disabled={isLast()}>
-      <RightCircleOutlined />
+      <Button className="nextPrevSelect-right-button" onClick={() => setCurrent_value(next())} disabled={isLast()}>
+      <CaretRightOutlined />
       </Button>
     </Flex>
   );

--- a/components/next_prev_select/index.tsx
+++ b/components/next_prev_select/index.tsx
@@ -1,0 +1,67 @@
+import { LeftCircleOutlined, LeftOutlined, RightCircleOutlined, RightOutlined, VerticalLeftOutlined, VerticalRightOutlined } from "@ant-design/icons"
+import { Button, Flex, Select, } from "antd"
+import { CSSProperties, useEffect, useState } from "react"
+
+
+
+export interface NextPrevSelectProps {
+    options?:any[]
+    style?:CSSProperties
+    defaultValue?:string
+    value?:string
+    onChange?:Function
+    reverse?:boolean // False : next = goDown
+  }
+
+export const NextPrevSelect: React.FC<NextPrevSelectProps> = ({
+  options = [],
+  style,
+  value,
+  defaultValue,
+  onChange,
+  reverse = false,
+}) => {
+  const [current_value, setCurrent_value] = useState(value);
+
+  const current_index = options?.findIndex((o) => o.value == current_value);
+
+  const next = () =>
+    reverse
+      ? options[current_index - 1].value
+      : options[current_index + 1].value;
+
+  const previous = () =>
+    reverse
+      ? options[current_index + 1].value
+      : options[current_index - 1].value;
+
+  const isFirst = () =>
+    reverse ? current_index == options.length - 1 : current_index == 0;
+
+  const isLast = () =>
+    reverse ? current_index == 0 : current_index == options.length - 1;
+
+
+  useEffect(() => {
+    onChange && onChange(current_value);
+  }, [current_value])
+
+
+  return (
+    <Flex style={style}>
+      <Button onClick={() => setCurrent_value(previous())} disabled={isFirst()}>
+      <LeftCircleOutlined />
+      </Button>
+      <Select
+        options={options}
+        style={style}
+        value={current_value}
+        defaultValue={defaultValue}
+        onChange={setCurrent_value}
+      />
+      <Button onClick={() => setCurrent_value(next())} disabled={isLast()}>
+      <RightCircleOutlined />
+      </Button>
+    </Flex>
+  );
+};


### PR DESCRIPTION
Ajout de `NextPrevSelect`, il s'agit d'un `Select` bordé de 2 boutons permettant d’accéder aux items suivants et précédents.
Utile un sélecteur d'années dans un tableau de bord.

![image](https://github.com/geo2france/g2f-dashboard/assets/6163107/7dcb1277-afc5-4fe2-96ae-5266efa35e17)

#1 

