### PR TITLE
unit test flipcard

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'  },
+  //setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  testMatch: ['**/?(*.)+(test).(ts|tsx)'],
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dataviz"
   ],
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "test": "jest --watch"
   },
   "dependencies": {
     "alasql": "^4.5.0",
@@ -33,22 +34,33 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.51.11",
-    "react-router-dom": "^6.25.1",
-    "react": "^18.3.1",
-    "antd": "^5.18.3",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/geojson": "^7946.0.14",
-    "@types/react": "^18.3.3",
+    "@types/jest": "^29.5.13",
+    "@types/node": "^22.7.3",
+    "@types/react": "^18.3.9",
+    "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",
     "@vitejs/plugin-react": "^4.3.1",
+    "antd": "^5.18.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "react": "^18.3.1",
+    "react-router-dom": "^6.25.1",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.2",
     "vite": "^5.3.4",
     "vite-plugin-svgr": "^4.2.0"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.51.11",
-    "react-router-dom": "^6.25.1",
     "antd": "^5.18.3",
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "react-router-dom": "^6.25.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "tsc": "tsc",
-    "test": "jest --watch"
+    "test": "jest --watchAll"
   },
   "dependencies": {
     "alasql": "^4.5.0",

--- a/src/components/DashboardElement/DashboardElement.tsx
+++ b/src/components/DashboardElement/DashboardElement.tsx
@@ -2,15 +2,15 @@ import {
   DownloadOutlined,
   FileImageOutlined,
   FullscreenOutlined,
-  MoreOutlined,
-  InfoCircleOutlined,
+  MoreOutlined
 } from "@ant-design/icons";
 import { HiQuestionMarkCircle } from "react-icons/hi2";
-import { Card, theme, Modal, Dropdown, MenuProps, Flex, CardProps, Button, Popover, Typography } from "antd";
+import { Card, theme, Modal, Dropdown, MenuProps, Flex, Button, Popover, Typography } from "antd";
 import React, { ReactElement, ReactNode, createContext, useEffect, useState } from "react";
 import Attribution, { SourceProps } from "../Attributions/Attributions";
 import { useChartExport } from "../../utils/usechartexports";
 import LoadingContainer from "../LoadingContainer/LoadingContainer";
+import { cardStyles } from "../../utils/cardStyles";
 
 const { useToken } = theme;
 
@@ -23,18 +23,6 @@ export const chartContext = createContext<any>({
 });
 
 type DataFileType = "csv" | "xlsx" | "ods";
-
-export const cardStyles: CardProps["styles"] = {
-  body: {
-    padding: "0px",
-  },
-  header: {
-    padding: "5px",
-    paddingLeft: "15px",
-    fontSize: 14,
-    minHeight: 35,
-  },
-};
 
 interface IDashboardElementProps {
   title: string;

--- a/src/components/FlipCard/FlipCard.test.tsx
+++ b/src/components/FlipCard/FlipCard.test.tsx
@@ -1,0 +1,52 @@
+import {render, screen} from '@testing-library/react'
+import FlipCard from "./FlipCard";
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event'
+
+
+const a_value = "Hello !"
+const b_value = "Ceci est une description"
+
+describe("FlipCard Component", () => {
+    
+    test("initial state", async () => {
+        // Génération DOM virtuel et sélection des noeuds
+        render(<FlipCard information={b_value}><span>{a_value}</span></FlipCard>);
+        const cardA = screen.getByText(a_value).closest('.ant-card'); // Recto
+        const cardB = screen.getByText(b_value).closest('.ant-card');  // Verso
+
+        // Assertions
+        expect(screen.queryByText(a_value)).toBeInTheDocument();
+        expect(screen.queryByText(b_value)).toBeInTheDocument();
+
+        expect(cardA).not.toHaveStyle('transform: rotateY(180deg)');
+        expect(cardB).toHaveStyle('transform: rotateY(180deg)');
+
+    });
+
+    test("flip the card", async () =>{
+        // initialisation user
+        const user = userEvent.setup();
+
+        // Génération DOM virtuel et sélection des noeuds
+        render(<FlipCard information={b_value}><span>{a_value}</span></FlipCard>);
+
+        const cardA = screen.getByText(a_value).closest('.ant-card'); // Recto
+        const cardB = screen.getByText(b_value).closest('.ant-card');  // Verso
+        const infoButton = screen.getAllByRole('button', {name:"info"}); // Bouton info (2 boutons identiques, un sur chaque face). A améliorer
+
+
+        // Assertions
+        await user.click(infoButton[0])
+
+        expect(cardA).toHaveStyle('transform: rotateY(180deg)');
+        expect(cardB).not.toHaveStyle('transform: rotateY(180deg)');
+
+        await user.click(infoButton[1])
+
+        expect(cardA).not.toHaveStyle('transform: rotateY(180deg)');
+        expect(cardB).toHaveStyle('transform: rotateY(180deg)');
+
+    })
+
+})

--- a/src/components/FlipCard/FlipCard.tsx
+++ b/src/components/FlipCard/FlipCard.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { Button, Card, Typography } from "antd"
 import { CSSProperties, ReactElement, useState } from "react"
 import { BsInfoCircle, BsInfoCircleFill } from "react-icons/bs"
-import { cardStyles } from '../DashboardElement/DashboardElement';
+import { cardStyles } from "../../utils/cardStyles";
 
 const { Text } = Typography;
 
@@ -40,6 +40,7 @@ const FlipCard: React.FC<FlipCardProps> = ({ title, information, children }) => 
               onClick={toggleFlipped}
               shape="circle"
               style={{ position: "absolute", right: 0, top: 0 }}
+              aria-label="info"
             >
               {flipped ? <BsInfoCircleFill /> : <BsInfoCircle />}
             </Button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { useChartData, useDashboardElement } from "./components/DashboardElement
 
 // Helpers
 export { BaseRecordToGeojsonPoint } from "./utils/baserecordtogeojsonpoint"
-export {cardStyles} from "./components/DashboardElement/DashboardElement"
+export {cardStyles} from "./utils/cardStyles"
 
 // Components
 import KeyFigure from "./components/KeyFigure/KeyFigure"

--- a/src/utils/cardStyles.tsx
+++ b/src/utils/cardStyles.tsx
@@ -1,0 +1,14 @@
+import { CardProps } from "antd";
+
+
+export const cardStyles: CardProps["styles"] = {
+  body: {
+    padding: "0px",
+  },
+  header: {
+    padding: "5px",
+    paddingLeft: "15px",
+    fontSize: 14,
+    minHeight: 35,
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "isolatedModules": true,
       "noEmit": true,
       "jsx": "react-jsx",
-      "types": ["vite-plugin-svgr/client"],
+      "types": ["vite-plugin-svgr/client", "jest", "@testing-library/jest-dom"],
       "noUnusedLocals": true
     },
     "include": ["src","src/custom.d.ts"],


### PR DESCRIPTION
Ajout de tests unitaires.

Test exemple pour `FlipCard`. Processus de travail à systématiser.

Pour lancer les tests : `npm run test`